### PR TITLE
Pas positie closing tags aan

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -14,16 +14,13 @@
         <% console.log(product.image) %>
         <source
           srcset="https://assets.ctfassets.net/x2maf5pkzgmb/<%= product.image %>?fm=avif"
-          type="image/avif"
-        />
+          type="image/avif"/>
         <source
           srcset="https://assets.ctfassets.net/x2maf5pkzgmb/<%= product.image %>?fm=webp"
-          type="image/webp"
-        />
+          type="image/webp"/>
         <img
           src="https://assets.ctfassets.net/x2maf5pkzgmb/<%= product.image %>"
-          alt="<%= product.name %>"
-        />
+          alt="<%= product.name %>"/>
       </picture>
 
       <p><%= product.description %></p>


### PR DESCRIPTION
De closing tags van de source en img elementen nemen nu een hele regel in beslag.  Het ziet er misschien cleaner uit om deze meteen achter de de rest van het element te zetten.